### PR TITLE
Refactor admin registration and improve logging

### DIFF
--- a/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommand.cs
+++ b/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommand.cs
@@ -24,5 +24,4 @@ public class AdminRegistrationResponse
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
-    public AuthResponse Tokens { get; set; } = new();
 }

--- a/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommandHandler.cs
+++ b/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommandHandler.cs
@@ -103,7 +103,6 @@ public class RegisterAdminCommandHandler : IRequestHandler<RegisterAdminCommand,
                 FirstName = adminUser.FirstName,
                 LastName = adminUser.LastName,
                 CreatedAt = adminUser.CreatedAt,
-                Tokens = authResponse
             };
 
             return GenericResponseModel<AdminRegistrationResponse>.Success(response);

--- a/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommandValidator.cs
+++ b/SnapNFix.Application/Features/Admin/Commands/RegisterAdmin/RegisterAdminCommandValidator.cs
@@ -2,16 +2,17 @@ using FluentValidation;
 using Microsoft.AspNetCore.Identity;
 using SnapNFix.Application.Resources;
 using SnapNFix.Domain.Entities;
+using SnapNFix.Domain.Interfaces;
 
 namespace SnapNFix.Application.Features.Admin.Commands.RegisterAdmin;
 
 public class RegisterAdminCommandValidator : AbstractValidator<RegisterAdminCommand>
 {
-    private readonly UserManager<User> _userManager;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public RegisterAdminCommandValidator(UserManager<User> userManager)
+    public RegisterAdminCommandValidator(IUnitOfWork unitOfWork)
     {
-        _userManager = userManager;
+        _unitOfWork = unitOfWork;
 
         RuleFor(x => x.FirstName)
             .NotEmpty().WithMessage(Shared.FirstNameRequired)
@@ -57,7 +58,7 @@ public class RegisterAdminCommandValidator : AbstractValidator<RegisterAdminComm
 
     private async Task<bool> BeUniqueEmail(string email, CancellationToken cancellationToken)
     {
-        var existingUser = await _userManager.FindByEmailAsync(email);
-        return existingUser == null;
+        var existingUser = _unitOfWork.Repository<User>().ExistsByName(u => u.Email == email);
+        return existingUser == false;
     }
 }

--- a/SnapNFix.Application/Features/Ai/AiValidation/ReportImageProcessing/ImageValidationResultCommandHandler.cs
+++ b/SnapNFix.Application/Features/Ai/AiValidation/ReportImageProcessing/ImageValidationResultCommandHandler.cs
@@ -100,7 +100,7 @@ public class ImageValidationResultCommandHandler : IRequestHandler<ImageValidati
                             report.Id, report.IssueId);
                         _backgroundTaskQueue.EnqueueScoped<IMediator>(async mediator => 
                         {
-                            await mediator.Publish(new SnapReportStatusChanged(report, oldStatus, request.ImageStatus), CancellationToken.None);
+                            await mediator.Publish(new IssueCreated(newIssue), CancellationToken.None);
                         });
                     }
                 }

--- a/SnapNFix.Application/Services/DeviceManager/DeviceManager.cs
+++ b/SnapNFix.Application/Services/DeviceManager/DeviceManager.cs
@@ -134,7 +134,7 @@ public class DeviceManager : IDeviceManager
     {
         var tokens = await _unitOfWork.Repository<UserDevice>()
             .FindBy(d => d.UserId == userId )
-            .Where(d => !string.IsNullOrEmpty(d.FCMToken) && d.RefreshToken != null && !d.RefreshToken.IsExpired)
+            .Where(d => !string.IsNullOrEmpty(d.FCMToken) && d.RefreshToken != null && d.RefreshToken.Expires > DateTime.UtcNow)
             .Select(d =>  d.FCMToken )
             .ToListAsync();
 

--- a/SnapNFix.Infrastructure/Services/AiService/PhotoValidationService/PhotoValidationService.cs
+++ b/SnapNFix.Infrastructure/Services/AiService/PhotoValidationService/PhotoValidationService.cs
@@ -37,6 +37,8 @@ public class PhotoValidationService : IPhotoValidationService
         {
             var aiEndpoint = _photoValidationOptions.ValidationEndpoint;
             var webhookUrl = _photoValidationOptions.WebhookUrl;
+            _logger.LogInformation("Preparing to send image for validation. ImageUrl: {ImageUrl}, WebhookUrl: {WebhookUrl}, Endpoint: {Endpoint}", 
+                imageUrl, webhookUrl, aiEndpoint);
 
             _logger.LogInformation("Sending image for validation to AI service. ImageUrl: {ImageUrl}, WebhookUrl: {WebhookUrl}", 
                 imageUrl, webhookUrl);

--- a/SnapNFix.Infrastructure/Services/FirebaseNotificationService/FirebaseNotificationService.cs
+++ b/SnapNFix.Infrastructure/Services/FirebaseNotificationService/FirebaseNotificationService.cs
@@ -86,7 +86,7 @@ namespace SnapNFix.Infrastructure.Services.FirebaseNotificationService
                         Data = data ?? new Dictionary<string, string>()
                     };
 
-                    var response = await _messaging.SendMulticastAsync(message);
+                    var response = await _messaging.SendEachForMulticastAsync(message);
                     
                     _logger.LogInformation(
                         "Notification sent to {SuccessCount}/{TotalCount} devices for user {UserId}", 


### PR DESCRIPTION
Removed token from AdminRegistrationResponse and updated handler accordingly. Refactored RegisterAdminCommandValidator to use IUnitOfWork instead of UserManager and fixed email uniqueness check. Changed DeviceManager token filtering to use expiration date. Updated AI image validation to publish IssueCreated event. Enhanced logging in PhotoValidationService and switched Firebase notification sending to SendEachForMulticastAsync.